### PR TITLE
Add the multi tenancy support on the document level.

### DIFF
--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -36,9 +36,7 @@ class Document(DocumentRow):
         if collection is not None:
             result = await collection.insert_one(data)
         else:
-            if isinstance(self.meta.from_collection, AsyncIOMotorCollection):
-                result = await self.meta.from_collection.insert_one(data)  # noqa
-            elif isinstance(self.meta.collection, Collection):
+            if isinstance(self.meta.collection, Collection):
                 result = await self.meta.collection._collection.insert_one(data)  # noqa
         self.id = result.inserted_id
 

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -92,7 +92,7 @@ class Document(DocumentRow):
 
         data = (model.model_dump(exclude={"id"}) for model in models)
         if isinstance(cls.meta.from_collection, AsyncIOMotorCollection):
-            results = await cls.meta.from_collection.insert_many(data)  # type: ignore
+            results = await cls.meta.from_collection.insert_many(data)
         else:
             results = await cls.meta.collection._collection.insert_many(data)  # type: ignore
         for model, inserted_id in zip(models, results.inserted_ids, strict=True):

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -37,7 +37,7 @@ class Document(DocumentRow):
             result = await collection.insert_one(data)
         else:
             if isinstance(self.meta.from_collection, AsyncIOMotorCollection):
-                result = await self.meta.from_collection._collection.insert_one(data)  # noqa
+                result = await self.meta.from_collection.insert_one(data)  # noqa
             elif isinstance(self.meta.collection, Collection):
                 result = await self.meta.collection._collection.insert_one(data)  # noqa
         self.id = result.inserted_id
@@ -55,7 +55,7 @@ class Document(DocumentRow):
             if isinstance(self.meta.from_collection, AsyncIOMotorCollection):
                 collection = self.meta.from_collection
             elif isinstance(self.meta.collection, Collection):
-                collection = self.meta.collection
+                collection = self.meta.collection._collection
         field_definitions = {
             name: (annotations, ...)
             for name, annotations in self.__annotations__.items()
@@ -301,7 +301,7 @@ class Document(DocumentRow):
             if isinstance(self.meta.from_collection, AsyncIOMotorCollection):
                 collection = self.meta.from_collection
             elif isinstance(self.meta.collection, Collection):
-                collection = self.meta.collection
+                collection = self.meta.collection._collection
         await self.signals.pre_delete.send(sender=self.__class__, instance=self)
 
         result = await collection.delete_one({"_id": self.id})
@@ -366,7 +366,7 @@ class Document(DocumentRow):
             if isinstance(self.meta.from_collection, AsyncIOMotorCollection):
                 collection = self.meta.from_collection
             elif isinstance(self.meta.collection, Collection):
-                collection = self.meta.collection
+                collection = self.meta.collection._collection
 
         if not self.id:
             return await self.create()

--- a/mongoz/core/db/documents/document.py
+++ b/mongoz/core/db/documents/document.py
@@ -75,7 +75,7 @@ class Document(DocumentRow):
             data.update(values)
 
             await self.signals.pre_update.send(sender=self.__class__, instance=self)
-            await collection.update_one({"_id": self.id}, {"$set": data})
+            await collection.update_one({"_id": self.id}, {"$set": data})  # type: ignore
             await self.signals.post_update.send(sender=self.__class__, instance=self)
 
             for k, v in data.items():
@@ -96,7 +96,7 @@ class Document(DocumentRow):
         if isinstance(cls.meta.from_collection, AsyncIOMotorCollection):
             results = await cls.meta.from_collection.insert_many(data)  # type: ignore
         else:
-            results = await cls.meta.collection._collection.insert_many(data)
+            results = await cls.meta.collection._collection.insert_many(data)  # type: ignore
         for model, inserted_id in zip(models, results.inserted_ids, strict=True):
             model.id = inserted_id
         return models
@@ -304,7 +304,7 @@ class Document(DocumentRow):
                 collection = self.meta.collection._collection
         await self.signals.pre_delete.send(sender=self.__class__, instance=self)
 
-        result = await collection.delete_one({"_id": self.id})
+        result = await collection.delete_one({"_id": self.id})  # type: ignore
         await self.signals.post_delete.send(sender=self.__class__, instance=self)
         return cast(int, result.deleted_count)
 
@@ -373,7 +373,7 @@ class Document(DocumentRow):
 
         await self.signals.pre_save.send(sender=self.__class__, instance=self)
 
-        await collection.update_one(
+        await collection.update_one(  # type: ignore
             {"_id": self.id}, {"$set": self.model_dump(exclude={"id", "_id"})}
         )
         for k, v in self.model_dump(exclude={"id"}).items():

--- a/mongoz/core/db/documents/document_row.py
+++ b/mongoz/core/db/documents/document_row.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Sequence, Type, Union, cast
 
 from motor.motor_asyncio import AsyncIOMotorCollection
+
 from mongoz.core.db.documents.base import MongozBaseModel
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/mongoz/core/db/documents/document_row.py
+++ b/mongoz/core/db/documents/document_row.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Sequence, Type, Union, cast
 
+from motor.motor_asyncio import AsyncIOMotorCollection
 from mongoz.core.db.documents.base import MongozBaseModel
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -19,6 +20,7 @@ class DocumentRow(MongozBaseModel):
         is_defer_fields: bool = False,
         only_fields: Union[Sequence[str], None] = None,
         defer_fields: Union[Sequence[str], None] = None,
+        from_collection:  Union[AsyncIOMotorCollection, None] = None
     ) -> Union[Type["Document"], None]:
         """
         Class method to convert a dictionary row result into a Document row type.
@@ -55,6 +57,7 @@ class DocumentRow(MongozBaseModel):
                     item[column] = value
 
         model = cast("Type[Document]", cls(**item))  # type: ignore
+        model.Meta.from_collection = from_collection
         return model
 
     @classmethod

--- a/mongoz/core/db/documents/metaclasses.py
+++ b/mongoz/core/db/documents/metaclasses.py
@@ -47,6 +47,7 @@ class MetaInfo:
         "database",
         "manager",
         "autogenerate_index",
+        "from_collection"
     )
 
     def __init__(self, meta: Any = None, **kwargs: Any) -> None:

--- a/mongoz/core/db/documents/metaclasses.py
+++ b/mongoz/core/db/documents/metaclasses.py
@@ -66,6 +66,7 @@ class MetaInfo:
         self.signals: Optional[Broadcaster] = {}  # type: ignore
         self.manager: "Manager" = getattr(meta, "manager", Manager())
         self.autogenerate_index: bool = getattr(meta, "autogenerate_index", False)
+        self.from_collection: bool = getattr(meta, "from_collection", None)
 
     def model_dump(self) -> Dict[Any, Any]:
         return {k: getattr(self, k, None) for k in self.__slots__}

--- a/mongoz/core/db/documents/metaclasses.py
+++ b/mongoz/core/db/documents/metaclasses.py
@@ -15,6 +15,7 @@ from typing import (
     no_type_check,
 )
 
+from motor.motor_asyncio import AsyncIOMotorCollection
 from pydantic._internal._model_construction import ModelMetaclass
 
 from mongoz.core.connection.collections import Collection
@@ -66,7 +67,7 @@ class MetaInfo:
         self.signals: Optional[Broadcaster] = {}  # type: ignore
         self.manager: "Manager" = getattr(meta, "manager", Manager())
         self.autogenerate_index: bool = getattr(meta, "autogenerate_index", False)
-        self.from_collection: bool = getattr(meta, "from_collection", None)
+        self.from_collection: Union[AsyncIOMotorCollection, None] = getattr(meta, "from_collection", None)
 
     def model_dump(self) -> Dict[Any, Any]:
         return {k: getattr(self, k, None) for k in self.__slots__}

--- a/mongoz/core/db/querysets/core/manager.py
+++ b/mongoz/core/db/querysets/core/manager.py
@@ -364,6 +364,7 @@ class Manager(QuerySetProtocol, AwaitableQuery[MongozDocument]):
                 only_fields=manager._only_fields,
                 is_defer_fields=is_defer_fields,
                 defer_fields=manager._defer_fields,
+                from_collection=manager._collection
             )
             async for document in cursor
         ]

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, AsyncGenerator
 
 import pydantic
 import pytest
@@ -21,6 +21,13 @@ class Movie(Document):
     class Meta:
         registry = client
         database = "test_db"
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def prepare_database() -> AsyncGenerator:
+    await Movie.objects.delete()
+    yield
+    await Movie.objects.delete()
 
 
 async def test_model_using_create() -> None:

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -88,7 +88,7 @@ async def test_model_save() -> None:
     movie = await Movie.objects.using("test_my_db").get()
     assert movie.name == "Harshali"
 
-    movie.name == "Harshali Zode"
+    movie.name = "Harshali Zode"
     await movie.save()
 
     movie = await Movie.objects.using("test_my_db").get()

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -25,9 +25,9 @@ class Movie(Document):
 
 @pytest.fixture(scope="function", autouse=True)
 async def prepare_database() -> AsyncGenerator:
-    await Movie.objects.delete()
+    await Movie.objects.using("test_my_db").delete()
     yield
-    await Movie.objects.delete()
+    await Movie.objects.using("test_my_db").delete()
 
 
 async def test_model_using_create() -> None:

--- a/tests/models/manager/test_using.py
+++ b/tests/models/manager/test_using.py
@@ -23,7 +23,7 @@ class Movie(Document):
         database = "test_db"
 
 
-async def test_model_using() -> None:
+async def test_model_using_create() -> None:
     await Movie.objects.create(name="Harshali", year=2024)
     await Movie.objects.using("test_my_db").create(name="Harshali Zode", year=2024)
 
@@ -34,6 +34,57 @@ async def test_model_using() -> None:
     assert movie.name == "Harshali Zode"
 
     movie = await Movie.objects.using("test_my_db").filter(name="Harshali Zode").get()
+    assert movie.name == "Harshali Zode"
+
+    movie = await Movie.objects.using("test_my_db").filter(_id=movie.id).get()
+    assert movie.name == "Harshali Zode"
+
+    with pytest.raises(DocumentNotFound):
+        await Movie.objects.filter(name="Harshali Zode").get()
+        await Movie.objects.using("test_my_db").filter(name="Harshali").get()
+
+
+async def test_model_using_update() -> None:
+    await Movie.objects.using("test_my_db").create(name="Harshali", year=2024)
+
+    movie = await Movie.objects.using("test_my_db").get()
+    assert movie.name == "Harshali"
+
+    await movie.update(name="Harshali Zode")
+
+    movie = await Movie.objects.using("test_my_db").get()
+    assert movie.name == "Harshali Zode"
+
+    movie = await Movie.objects.using("test_my_db").filter(_id=movie.id).get()
+    assert movie.name == "Harshali Zode"
+
+    with pytest.raises(DocumentNotFound):
+        await Movie.objects.filter(name="Harshali Zode").get()
+        await Movie.objects.using("test_my_db").filter(name="Harshali").get()
+
+
+async def test_model_delete() -> None:
+    await Movie.objects.using("test_my_db").create(name="Harshali Zode", year=2024)
+
+    movie = await Movie.objects.using("test_my_db").get()
+    assert movie.name == "Harshali Zode"
+
+    await movie.delete()
+
+    with pytest.raises(DocumentNotFound):
+        movie = await Movie.objects.using("test_my_db").get()
+
+
+async def test_model_save() -> None:
+    await Movie.objects.using("test_my_db").create(name="Harshali", year=2024)
+
+    movie = await Movie.objects.using("test_my_db").get()
+    assert movie.name == "Harshali"
+
+    movie.name == "Harshali Zode"
+    await movie.save()
+
+    movie = await Movie.objects.using("test_my_db").get()
     assert movie.name == "Harshali Zode"
 
     movie = await Movie.objects.using("test_my_db").filter(_id=movie.id).get()


### PR DESCRIPTION
**Add the Multi tenancy support on the Document.**
Adding the pull request since the **using()** technique allows us to use the managers' queries without interruption. But when we try to query at the document level then it picks the default database that configured in the meta class rather than the one it was fetched originally from.

To resolve this issue, I have added the **from_collection** attribute to the meta class, and when we construct the Document object, we set this attribute to store the manager's collection object so that the operation should be performed on the same database that was requested by **using()**.